### PR TITLE
Run jekyll build with config variables

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -111,10 +111,21 @@ WARNING
 
 private
 
+  def jekyll_environment_variables
+    puts "Setting up jekyll environment variables"
+    variables = user_env_hash.select do |key, value|
+      key =~ /^JEKYLL_/
+    end
+
+    variables.reduce("") do |env, (key, value)|
+      "#{env} #{key}=#{value}"
+    end
+  end
+
   # generate jekyll
   def generate_jekyll_site
     puts "Building jekyll site"
-    pipe("env PATH=$PATH bundle exec jekyll build --trace 2>&1")
+    pipe("env PATH=$PATH #{jekyll_environment_variables} bundle exec jekyll build --trace 2>&1")
     unless $? == 0
       error "Failed to generate site with jekyll."
     end


### PR DESCRIPTION
##### What does this PR do?

Enables `jekyll build` to be run with config variables.

Config vars are passed to the buildpack as an argument
(versus being set in the environment as it happens for commands
in the Procfile or when running one-off processes) as explained
in the link below (search for ENV_DIR):
https://devcenter.heroku.com/articles/buildpack-api

As a result the config variables I needed for `jekyll build` were not
being automatically passed to it.

Config variables are particularly useful whenever we have things
that we do not want to commit to a git repository (e.g. google analytics
keys) or whenever we want to load different assets in production/development
(e.g. minified CSS files). Examples:
https://github.com/marionzualo/www/blob/ec01d61035a2aaa832e985eee2651edafb4c2747/_includes/_head.html#L11
https://github.com/marionzualo/www/blob/ec01d61035a2aaa832e985eee2651edafb4c2747/_includes/_head.html#L17

Heroku docs on config vars:
https://devcenter.heroku.com/articles/config-vars
##### How should this be manually tested?

Testing this involves (I can give more details or set up a test app if you are interested):
- Setting a config var `heroku config:set JEKYLL_TEST=true`
- Changing the jekyll template to do some conditional on this variable (You need to have the [ability to read environment variables from your liquid template](https://github.com/ajwhite/jekyll-environment-variables))

``` html
{% if site.env.JEKYLL_TEST %}
    <p> It works! </p>
{% endif %}
```
- Deploy to Heroku and confirm the text above is shown
##### Any background context you want to provide?

I don't know if this is actually useful to you. I am OK with it not being merged, I just figured it could be helpful to others as well.
